### PR TITLE
python 2.7 compatibility, working (tested) with tornado==3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license          = 'MIT',
     keywords         = ['smtp', 'email', 'mail', 'tornado', 'async'],
     packages         = ['tornado_smtp'],
-    install_requires = ['tornado >= 4.0.0'],
+    install_requires = ['tornado >= 3.2.0'],
     classifiers      = [
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -29,5 +29,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 2.7'
     ],
 )

--- a/tornado_smtp/client.py
+++ b/tornado_smtp/client.py
@@ -5,6 +5,7 @@ from smtplib import SMTP, SMTP_SSL
 from concurrent.futures import ThreadPoolExecutor
 from tornado import gen
 
+
 class TornadoSMTP:
     def initialized_async(func):
         @functools.wraps(func)
@@ -13,19 +14,19 @@ class TornadoSMTP:
             if self._busy:
                 self._smtp = yield self._busy
                 self._busy = None
-            
+
             result = yield func(self, *args, **kwargs)
-            return result
-    
+            raise gen.Return(result)
+
         return wrapper
 
-    def __init__(self, host='', port=0, local_hostname=None, timeout=_GLOBAL_DEFAULT_TIMEOUT, 
+    def __init__(self, host='', port=0, local_hostname=None, timeout=_GLOBAL_DEFAULT_TIMEOUT,
                  source_address=None, use_ssl=False, keyfile=None, certfile=None, context=None):
         self._pool = ThreadPoolExecutor(os.cpu_count() or 1)
         self._busy = self._pool.submit(self._initialize, host, port, local_hostname, timeout,
                                        source_address, use_ssl, keyfile, certfile, context)
-    
-    def _initialize(self, host='', port=0, local_hostname=None, timeout=_GLOBAL_DEFAULT_TIMEOUT, 
+
+    def _initialize(self, host='', port=0, local_hostname=None, timeout=_GLOBAL_DEFAULT_TIMEOUT,
                     source_address=None, use_ssl=False, keyfile=None, certfile=None, context=None):
         return (SMTP_SSL(host, port, local_hostname, keyfile, certfile, timeout, context, source_address)
                 if use_ssl else SMTP(host, port, local_hostname, timeout, source_address))

--- a/tornado_smtp/client.py
+++ b/tornado_smtp/client.py
@@ -2,8 +2,13 @@ import os
 import functools
 from socket import _GLOBAL_DEFAULT_TIMEOUT
 from smtplib import SMTP, SMTP_SSL
-from concurrent.futures import ThreadPoolExecutor
 from tornado import gen
+
+
+try:
+    from concurrent.futures import ThreadPoolExecutor
+except:
+    from futures import ThreadPoolExecutor
 
 
 class TornadoSMTP:


### PR DESCRIPTION
Changes:
- gen.Return instead of return in coroutine - transparent for new versions
- setupy.py require tornado >= 3.2.0
- flake8
